### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkHigherOrderAccurateDerivativeImageFilter.h
+++ b/include/itkHigherOrderAccurateDerivativeImageFilter.h
@@ -50,6 +50,8 @@ class HigherOrderAccurateDerivativeImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(HigherOrderAccurateDerivativeImageFilter);
+
   /** Standard class type alias. */
   using Self = HigherOrderAccurateDerivativeImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -136,9 +138,6 @@ protected:
   void GenerateData() override;
 
 private:
-  HigherOrderAccurateDerivativeImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);        //purposely not implemented
-
   /** The order of the derivative. */
   unsigned int m_Order;
 

--- a/include/itkHigherOrderAccurateGradientImageFilter.h
+++ b/include/itkHigherOrderAccurateGradientImageFilter.h
@@ -56,6 +56,8 @@ class HigherOrderAccurateGradientImageFilter: public ImageToImageFilter< TInputI
   Image< CovariantVector< TOutputValueType, TInputImage::ImageDimension >, TInputImage::ImageDimension > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(HigherOrderAccurateGradientImageFilter);
+
   /** Extract dimension from input image. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
@@ -149,9 +151,6 @@ protected:
   void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
 private:
-  HigherOrderAccurateGradientImageFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & );                 // purposely not implemented
-
   bool m_UseImageSpacing;
 
   // flag to take or not the image direction into account


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.