### PR TITLE
STYLE: Use "typename" for template parameters.

### DIFF
--- a/include/itkHigherOrderAccurateDerivativeImageFilter.hxx
+++ b/include/itkHigherOrderAccurateDerivativeImageFilter.hxx
@@ -27,7 +27,7 @@
 namespace itk
 {
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 HigherOrderAccurateDerivativeImageFilter< TInputImage, TOutputImage >
 ::GenerateInputRequestedRegion()
@@ -84,7 +84,7 @@ HigherOrderAccurateDerivativeImageFilter< TInputImage, TOutputImage >
 }
 
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 HigherOrderAccurateDerivativeImageFilter< TInputImage, TOutputImage >
 ::GenerateData()
@@ -150,7 +150,7 @@ HigherOrderAccurateDerivativeImageFilter< TInputImage, TOutputImage >
 }
 
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 HigherOrderAccurateDerivativeImageFilter< TInputImage, TOutputImage >::PrintSelf(std::ostream & os, Indent indent) const
 {


### PR DESCRIPTION
As discussed in:
http://review.source.kitware.com/#/c/12655/

the use of the template keyword "class" was substituted by "typename" in
the toolkit for the reasons stated in that topic.