### PR TITLE
ENH: Use batch with Azure Pipelines build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,10 @@ variables:
   CMakeBuildType: MinSizeRel
 
 trigger:
-- master
+  batch: true
+  branches:
+    include:
+    - master
 
 jobs:
 


### PR DESCRIPTION
As we adopt more module builds with the InsightSoftwareConsortium Azure
Pipelines account, this will help keep the builds down.

Reference: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml