### PR TITLE
COMP: Add missing ';' at end of macro

### DIFF
--- a/include/itkHigherOrderAccurateGradientImageFilter.h
+++ b/include/itkHigherOrderAccurateGradientImageFilter.h
@@ -120,7 +120,7 @@ public:
   /** Set/Get the order of accuracy of the derivative operator.  For more
    * information, see HigherOrderAccurateDerivativeOperator. */
   itkSetMacro(OrderOfAccuracy, unsigned int);
-  itkGetConstMacro(OrderOfAccuracy, unsigned int)
+  itkGetConstMacro(OrderOfAccuracy, unsigned int);
 
     protected : HigherOrderAccurateGradientImageFilter();
   ~HigherOrderAccurateGradientImageFilter() override = default;


### PR DESCRIPTION
A ';' is required at the end of macros in a future version of ITK. This will resolve build conflicts in source ITK. However, this will likely break the CI for this module until the changes are released in a future version of ITK and the CI is updated with the new version.