### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkHigherOrderAccurateDerivativeImageFilter.hxx
+++ b/include/itkHigherOrderAccurateDerivativeImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkHigherOrderAccurateDerivativeImageFilter_hxx
 #define itkHigherOrderAccurateDerivativeImageFilter_hxx
-#include "itkHigherOrderAccurateDerivativeImageFilter.h"
 
 #include "itkNumericTraits.h"
 #include "itkNeighborhoodOperatorImageFilter.h"

--- a/include/itkHigherOrderAccurateDerivativeOperator.hxx
+++ b/include/itkHigherOrderAccurateDerivativeOperator.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkHigherOrderAccurateDerivativeOperator_hxx
 #define itkHigherOrderAccurateDerivativeOperator_hxx
-#include "itkHigherOrderAccurateDerivativeOperator.h"
 
 #include "itkNumericTraits.h"
 

--- a/include/itkHigherOrderAccurateGradientImageFilter.hxx
+++ b/include/itkHigherOrderAccurateGradientImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkHigherOrderAccurateGradientImageFilter_hxx
 #define itkHigherOrderAccurateGradientImageFilter_hxx
-#include "itkHigherOrderAccurateGradientImageFilter.h"
 
 #include "itkConstNeighborhoodIterator.h"
 #include "itkNeighborhoodInnerProduct.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

